### PR TITLE
Add typescript module definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 package-lock.json
+yarn.lock
 node_modules/
 *.swp
 *~

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,38 @@
+declare module "newredis" {
+    import { Logger } from "colourlogger";
+    import { Socket } from "net";
+
+    export class RedisConnection extends Logger {
+        readonly config: RedisConnectionConfig;
+        constructor(config?: RedisConnectionConfig);
+        bindEndEvent(fn: () => void): void;
+        execute(command: any[]): Promise<any>;
+        getRawTCPConnection(): Socket;
+        initialize(): Promise<void>;
+    }
+
+    export interface RedisConnectionConfig {
+        dbNum?: number;
+        host: string;
+        password?: string;
+        port?: number;
+    }
+
+    export class RedisConnectionPool extends Logger {
+        constructor(config?: RedisConnectionPoolConfig);
+        getConnection(): Promise<PoolConnection>;
+        showPoolStatus(): void;
+        emptyQueue(): void;
+        readonly config: RedisConnectionPoolConfig;
+    }
+
+    export class PoolConnection extends Logger {
+        constructor(config: RedisConnectionConfig);
+        execute(command: any[]): Promise<any>;
+        release(): void;
+    }
+
+    export interface RedisConnectionPoolConfig extends RedisConnectionConfig {
+        connectionLimit?: number;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -23,5 +23,6 @@
   },
   "engines": {
     "node": ">=7.0"
-  }
+  },
+  "types": "./index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/wallacegibbon/newredis-node.git"
   },
   "dependencies": {
-    "colourlogger": "^1.2.4",
+    "colourlogger": "rthadr/colourlogger",
     "redis-parser": "^3.0.0"
   },
   "engines": {


### PR DESCRIPTION
First, thanks for creating and sharing your work. I've created some Typescript definitions for this library. It would be awesome to use this library in Typescript projects. According to Typescript best practices, it is advised to ask the library maintainer to add definitions directly to the npm module. If you're interested, I'd also be happy to maintain these .d.ts files for you as I'm building a Library based on this module.

Please review the file and see if you feel I've covered what should be the public API surface.

Thanks,
Thad